### PR TITLE
Some changes I forgot to merge

### DIFF
--- a/pdrs4all/pipeline/default_settings.py
+++ b/pdrs4all/pipeline/default_settings.py
@@ -52,7 +52,14 @@ def pipeline_class_and_options_dict(stage, instrument, output_dir):
     if stage == 1:
         class_name = Detector1Pipeline
         if instrument == "NRS_IFU":
-            options["steps"] = {"clean_flicker_noise": skiptrue}
+            options["steps"] = {
+                "clean_flicker_noise": {
+                    "skip": False,
+                    "mask_science_regions": True,
+                    "fit_method": "fft",
+                    "background_method": "model",
+                }
+            }
 
     if instrument == "NRS_IFU":
         if stage == 2:

--- a/pdrs4all/pipeline/default_settings.py
+++ b/pdrs4all/pipeline/default_settings.py
@@ -93,6 +93,8 @@ def pipeline_class_and_options_dict(stage, instrument, output_dir):
                         # "refpix": skiptrue,
                         # "reset": skiptrue,
                         # "rscd": skiptrue,
+                        "jump": skiptrue,
+                        "ramp_fit": {"algorithm": "LIKELY"},
                     }
                 }
             )

--- a/pdrs4all/plot/templates_compare.py
+++ b/pdrs4all/plot/templates_compare.py
@@ -3,6 +3,7 @@ from matplotlib import pyplot as plt
 from argparse import ArgumentParser
 import numpy as np
 from matplotlib import ticker
+from pdrs4all.plot.templates_overview import nice_ticks
 
 
 def main():
@@ -45,18 +46,25 @@ def compare_one_template(t1, t2, label1, label2, k):
 
     """
     fig, axs = plt.subplots(2, 1, height_ratios=[2, 1], sharex=True)
+    for ax in axs:
+        nice_ticks(ax)
 
     w1 = t1["wavelength"]
     w2 = t2["wavelength"]
     f1 = t1[f"flux_{k}"]
     f2 = t2[f"flux_{k}"]
 
-    axs[0].plot(w1, f1, label=label1)
-    axs[0].plot(w2, f2, label=label2)
+    axs[0].plot(w1, f1, label=label1, drawstyle='steps-mid')
+    axs[0].plot(w2, f2, label=label2, drawstyle='steps-mid')
 
-    residual = (f2 - f1) / (0.5 * (f1 + f2))
-    axs[1].plot(w1, residual * 100, color="k")
-    axs[1].set_ylabel("(orange - blue) / (0.5 * (orange + blue)) [percent]", ha="left")
+    if len(f2) == len(f1):
+        residual = (f2 - f1) / (0.5 * (f1 + f2))
+        axs[1].plot(w1, residual * 100, color="k")
+        axs[1].set_ylabel("(orange - blue) / (0.5 * (orange + blue)) [percent]", ha="left")
+        axs[1].set_yscale("asinh")
+        axs[1].tick_params(which="minor", left=True)
+    else:
+        print("Cannot directly compute residuals because wavelength grids are different")
 
     axs[0].set_title(k)
     axs[0].legend()
@@ -69,8 +77,6 @@ def compare_one_template(t1, t2, label1, label2, k):
     axs[0].xaxis.set_minor_formatter(ticker.NullFormatter())
     axs[0].xaxis.set_major_formatter(ticker.ScalarFormatter())
 
-    axs[1].set_yscale("asinh")
-    axs[1].tick_params(which="minor", left=True)
 
 
 if __name__ == "__main__":

--- a/pdrs4all/plot/templates_overview.py
+++ b/pdrs4all/plot/templates_overview.py
@@ -8,6 +8,7 @@ together with the data products .
 from astropy.table import Table
 from argparse import ArgumentParser
 from matplotlib import pyplot as plt
+from matplotlib.ticker import AutoMinorLocator
 
 COLORS = ["b", "orange", "g", "r", "m"]
 
@@ -42,14 +43,34 @@ if __name__ == "__main__":
     Files containing extractions for individual cubes. These segments
     will be plotted to inspect how well the stitching works.""",
     )
+    ap.add_argument(
+        "--keys",
+        nargs="+",
+        help='Which template to plot. E.g. "Atomic" or "DF3"',
+        default=["HII", "Atomic", "DF1", "DF2", "DF3"],
+    )
     args = ap.parse_args()
 
     t = Table.read(args.templates_ecsv)
-    suffixes = [s.split("_", 1)[1] for s in t.colnames if "flux" in s]
+    suffixes = args.keys
 
     print("Plotting templates ", suffixes)
 
-    fig, axs = plt.subplots(3, 1, sharex=True)
+    fig, axs = plt.subplots(3, 1, sharex=True, height_ratios=[2,1,1])
+
+    for ax in axs:
+        ax.xaxis.set_minor_locator(AutoMinorLocator())
+        ax.yaxis.set_minor_locator(AutoMinorLocator())
+        ax.tick_params(
+            which="both",
+            axis="both",
+            top=True,
+            bottom=True,
+            left=True,
+            right=True,
+            labelbottom=True,
+        )
+
     wavelength = t["wavelength"]
     for i, k in enumerate(suffixes):
         flux = t[f"flux_{k}"]
@@ -85,9 +106,6 @@ if __name__ == "__main__":
                 )
 
     axs[0].legend()
-    # for ax in axs:
-    #     ax.set_yscale('log')
-
     fig.set_size_inches(8, 8)
     fig.tight_layout()
 

--- a/pdrs4all/plot/templates_overview.py
+++ b/pdrs4all/plot/templates_overview.py
@@ -13,6 +13,20 @@ from matplotlib.ticker import AutoMinorLocator
 COLORS = ["b", "orange", "g", "r", "m"]
 
 
+def nice_ticks(ax):
+    ax.xaxis.set_minor_locator(AutoMinorLocator())
+    ax.yaxis.set_minor_locator(AutoMinorLocator())
+    ax.tick_params(
+        which="both",
+        axis="both",
+        top=True,
+        bottom=True,
+        left=True,
+        right=True,
+        labelbottom=True,
+    )
+
+
 def flux_and_snr(ax_f, ax_u, ax_snr, w, f, u, **plot_kwargs):
     ax_f.plot(w, f, **plot_kwargs)
     ax_f.set_ylabel("flux (MJy sr-1)")
@@ -56,20 +70,10 @@ if __name__ == "__main__":
 
     print("Plotting templates ", suffixes)
 
-    fig, axs = plt.subplots(3, 1, sharex=True, height_ratios=[2,1,1])
+    fig, axs = plt.subplots(3, 1, sharex=True, height_ratios=[2, 1, 1])
 
     for ax in axs:
-        ax.xaxis.set_minor_locator(AutoMinorLocator())
-        ax.yaxis.set_minor_locator(AutoMinorLocator())
-        ax.tick_params(
-            which="both",
-            axis="both",
-            top=True,
-            bottom=True,
-            left=True,
-            right=True,
-            labelbottom=True,
-        )
+        nice_ticks(ax)
 
     wavelength = t["wavelength"]
     for i, k in enumerate(suffixes):

--- a/pdrs4all/plot/templates_overview.py
+++ b/pdrs4all/plot/templates_overview.py
@@ -55,7 +55,15 @@ if __name__ == "__main__":
         flux = t[f"flux_{k}"]
         unc = t[f"unc_{k}"]
         flux_and_snr(
-            axs[0], axs[1], axs[2], wavelength, flux, unc, label=k, color=COLORS[i]
+            axs[0],
+            axs[1],
+            axs[2],
+            wavelength,
+            flux,
+            unc,
+            label=k,
+            color=COLORS[i],
+            drawstyle="steps-mid",
         )
 
     if args.segments_ecsv is not None:

--- a/pdrs4all/plot/templates_overview.py
+++ b/pdrs4all/plot/templates_overview.py
@@ -16,7 +16,7 @@ def flux_and_snr(ax_f, ax_u, ax_snr, w, f, u, **plot_kwargs):
     ax_f.plot(w, f, **plot_kwargs)
     ax_f.set_ylabel("flux (MJy sr-1)")
     ax_u.plot(w, u, **plot_kwargs)
-    ax_f.set_ylabel("unc (MJy sr-1)")
+    ax_u.set_ylabel("unc (MJy sr-1)")
     ax_snr.plot(w, f / u, **plot_kwargs)
     ax_snr.set_ylabel("S/N")
 

--- a/pdrs4all/postprocess/wcscorr.py
+++ b/pdrs4all/postprocess/wcscorr.py
@@ -183,7 +183,7 @@ def nirspec_wcscorr_using_proplyd(reference_image, current_wcs):
         C_PROPLYD_NIRSPEC, reference_image, current_wcs
     )
     dra, ddec = delta_ra_dec_pixel_vs_ref_coord(C_PROPLYD_NIRSPEC, xc, yc, current_wcs)
-    return apply_delta_ra_dec_to_wcs(current_wcs, dra, ddec)
+    return apply_delta_ra_dec_to_wcs(current_wcs, (dra, ddec))
 
 
 def mrs_wcscorr_using_proplyd(images, current_wcss):

--- a/poetry.lock
+++ b/poetry.lock
@@ -2242,8 +2242,8 @@ files = [
 
 [package.dependencies]
 numpy = [
-    {version = ">=1.26.0", markers = "python_version >= \"3.12\""},
     {version = ">=1.23.5", markers = "python_version >= \"3.11\" and python_version < \"3.12\""},
+    {version = ">=1.26.0", markers = "python_version >= \"3.12\""},
 ]
 
 [[package]]
@@ -2267,6 +2267,91 @@ files = [
     {file = "packaging-24.2-py3-none-any.whl", hash = "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759"},
     {file = "packaging-24.2.tar.gz", hash = "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f"},
 ]
+
+[[package]]
+name = "pandas"
+version = "2.2.3"
+description = "Powerful data structures for data analysis, time series, and statistics"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "pandas-2.2.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:1948ddde24197a0f7add2bdc4ca83bf2b1ef84a1bc8ccffd95eda17fd836ecb5"},
+    {file = "pandas-2.2.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:381175499d3802cde0eabbaf6324cce0c4f5d52ca6f8c377c29ad442f50f6348"},
+    {file = "pandas-2.2.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d9c45366def9a3dd85a6454c0e7908f2b3b8e9c138f5dc38fed7ce720d8453ed"},
+    {file = "pandas-2.2.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:86976a1c5b25ae3f8ccae3a5306e443569ee3c3faf444dfd0f41cda24667ad57"},
+    {file = "pandas-2.2.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:b8661b0238a69d7aafe156b7fa86c44b881387509653fdf857bebc5e4008ad42"},
+    {file = "pandas-2.2.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:37e0aced3e8f539eccf2e099f65cdb9c8aa85109b0be6e93e2baff94264bdc6f"},
+    {file = "pandas-2.2.3-cp310-cp310-win_amd64.whl", hash = "sha256:56534ce0746a58afaf7942ba4863e0ef81c9c50d3f0ae93e9497d6a41a057645"},
+    {file = "pandas-2.2.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:66108071e1b935240e74525006034333f98bcdb87ea116de573a6a0dccb6c039"},
+    {file = "pandas-2.2.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7c2875855b0ff77b2a64a0365e24455d9990730d6431b9e0ee18ad8acee13dbd"},
+    {file = "pandas-2.2.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cd8d0c3be0515c12fed0bdbae072551c8b54b7192c7b1fda0ba56059a0179698"},
+    {file = "pandas-2.2.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c124333816c3a9b03fbeef3a9f230ba9a737e9e5bb4060aa2107a86cc0a497fc"},
+    {file = "pandas-2.2.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:63cc132e40a2e084cf01adf0775b15ac515ba905d7dcca47e9a251819c575ef3"},
+    {file = "pandas-2.2.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:29401dbfa9ad77319367d36940cd8a0b3a11aba16063e39632d98b0e931ddf32"},
+    {file = "pandas-2.2.3-cp311-cp311-win_amd64.whl", hash = "sha256:3fc6873a41186404dad67245896a6e440baacc92f5b716ccd1bc9ed2995ab2c5"},
+    {file = "pandas-2.2.3-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:b1d432e8d08679a40e2a6d8b2f9770a5c21793a6f9f47fdd52c5ce1948a5a8a9"},
+    {file = "pandas-2.2.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a5a1595fe639f5988ba6a8e5bc9649af3baf26df3998a0abe56c02609392e0a4"},
+    {file = "pandas-2.2.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5de54125a92bb4d1c051c0659e6fcb75256bf799a732a87184e5ea503965bce3"},
+    {file = "pandas-2.2.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fffb8ae78d8af97f849404f21411c95062db1496aeb3e56f146f0355c9989319"},
+    {file = "pandas-2.2.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:6dfcb5ee8d4d50c06a51c2fffa6cff6272098ad6540aed1a76d15fb9318194d8"},
+    {file = "pandas-2.2.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:062309c1b9ea12a50e8ce661145c6aab431b1e99530d3cd60640e255778bd43a"},
+    {file = "pandas-2.2.3-cp312-cp312-win_amd64.whl", hash = "sha256:59ef3764d0fe818125a5097d2ae867ca3fa64df032331b7e0917cf5d7bf66b13"},
+    {file = "pandas-2.2.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f00d1345d84d8c86a63e476bb4955e46458b304b9575dcf71102b5c705320015"},
+    {file = "pandas-2.2.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:3508d914817e153ad359d7e069d752cdd736a247c322d932eb89e6bc84217f28"},
+    {file = "pandas-2.2.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:22a9d949bfc9a502d320aa04e5d02feab689d61da4e7764b62c30b991c42c5f0"},
+    {file = "pandas-2.2.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f3a255b2c19987fbbe62a9dfd6cff7ff2aa9ccab3fc75218fd4b7530f01efa24"},
+    {file = "pandas-2.2.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:800250ecdadb6d9c78eae4990da62743b857b470883fa27f652db8bdde7f6659"},
+    {file = "pandas-2.2.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6374c452ff3ec675a8f46fd9ab25c4ad0ba590b71cf0656f8b6daa5202bca3fb"},
+    {file = "pandas-2.2.3-cp313-cp313-win_amd64.whl", hash = "sha256:61c5ad4043f791b61dd4752191d9f07f0ae412515d59ba8f005832a532f8736d"},
+    {file = "pandas-2.2.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:3b71f27954685ee685317063bf13c7709a7ba74fc996b84fc6821c59b0f06468"},
+    {file = "pandas-2.2.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:38cf8125c40dae9d5acc10fa66af8ea6fdf760b2714ee482ca691fc66e6fcb18"},
+    {file = "pandas-2.2.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ba96630bc17c875161df3818780af30e43be9b166ce51c9a18c1feae342906c2"},
+    {file = "pandas-2.2.3-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1db71525a1538b30142094edb9adc10be3f3e176748cd7acc2240c2f2e5aa3a4"},
+    {file = "pandas-2.2.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:15c0e1e02e93116177d29ff83e8b1619c93ddc9c49083f237d4312337a61165d"},
+    {file = "pandas-2.2.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:ad5b65698ab28ed8d7f18790a0dc58005c7629f227be9ecc1072aa74c0c1d43a"},
+    {file = "pandas-2.2.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:bc6b93f9b966093cb0fd62ff1a7e4c09e6d546ad7c1de191767baffc57628f39"},
+    {file = "pandas-2.2.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:5dbca4c1acd72e8eeef4753eeca07de9b1db4f398669d5994086f788a5d7cc30"},
+    {file = "pandas-2.2.3-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8cd6d7cc958a3910f934ea8dbdf17b2364827bb4dafc38ce6eef6bb3d65ff09c"},
+    {file = "pandas-2.2.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:99df71520d25fade9db7c1076ac94eb994f4d2673ef2aa2e86ee039b6746d20c"},
+    {file = "pandas-2.2.3-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:31d0ced62d4ea3e231a9f228366919a5ea0b07440d9d4dac345376fd8e1477ea"},
+    {file = "pandas-2.2.3-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:7eee9e7cea6adf3e3d24e304ac6b8300646e2a5d1cd3a3c2abed9101b0846761"},
+    {file = "pandas-2.2.3-cp39-cp39-win_amd64.whl", hash = "sha256:4850ba03528b6dd51d6c5d273c46f183f39a9baf3f0143e566b89450965b105e"},
+    {file = "pandas-2.2.3.tar.gz", hash = "sha256:4f18ba62b61d7e192368b84517265a99b4d7ee8912f8708660fb4a366cc82667"},
+]
+
+[package.dependencies]
+numpy = [
+    {version = ">=1.23.2", markers = "python_version == \"3.11\""},
+    {version = ">=1.26.0", markers = "python_version >= \"3.12\""},
+]
+python-dateutil = ">=2.8.2"
+pytz = ">=2020.1"
+tzdata = ">=2022.7"
+
+[package.extras]
+all = ["PyQt5 (>=5.15.9)", "SQLAlchemy (>=2.0.0)", "adbc-driver-postgresql (>=0.8.0)", "adbc-driver-sqlite (>=0.8.0)", "beautifulsoup4 (>=4.11.2)", "bottleneck (>=1.3.6)", "dataframe-api-compat (>=0.1.7)", "fastparquet (>=2022.12.0)", "fsspec (>=2022.11.0)", "gcsfs (>=2022.11.0)", "html5lib (>=1.1)", "hypothesis (>=6.46.1)", "jinja2 (>=3.1.2)", "lxml (>=4.9.2)", "matplotlib (>=3.6.3)", "numba (>=0.56.4)", "numexpr (>=2.8.4)", "odfpy (>=1.4.1)", "openpyxl (>=3.1.0)", "pandas-gbq (>=0.19.0)", "psycopg2 (>=2.9.6)", "pyarrow (>=10.0.1)", "pymysql (>=1.0.2)", "pyreadstat (>=1.2.0)", "pytest (>=7.3.2)", "pytest-xdist (>=2.2.0)", "python-calamine (>=0.1.7)", "pyxlsb (>=1.0.10)", "qtpy (>=2.3.0)", "s3fs (>=2022.11.0)", "scipy (>=1.10.0)", "tables (>=3.8.0)", "tabulate (>=0.9.0)", "xarray (>=2022.12.0)", "xlrd (>=2.0.1)", "xlsxwriter (>=3.0.5)", "zstandard (>=0.19.0)"]
+aws = ["s3fs (>=2022.11.0)"]
+clipboard = ["PyQt5 (>=5.15.9)", "qtpy (>=2.3.0)"]
+compression = ["zstandard (>=0.19.0)"]
+computation = ["scipy (>=1.10.0)", "xarray (>=2022.12.0)"]
+consortium-standard = ["dataframe-api-compat (>=0.1.7)"]
+excel = ["odfpy (>=1.4.1)", "openpyxl (>=3.1.0)", "python-calamine (>=0.1.7)", "pyxlsb (>=1.0.10)", "xlrd (>=2.0.1)", "xlsxwriter (>=3.0.5)"]
+feather = ["pyarrow (>=10.0.1)"]
+fss = ["fsspec (>=2022.11.0)"]
+gcp = ["gcsfs (>=2022.11.0)", "pandas-gbq (>=0.19.0)"]
+hdf5 = ["tables (>=3.8.0)"]
+html = ["beautifulsoup4 (>=4.11.2)", "html5lib (>=1.1)", "lxml (>=4.9.2)"]
+mysql = ["SQLAlchemy (>=2.0.0)", "pymysql (>=1.0.2)"]
+output-formatting = ["jinja2 (>=3.1.2)", "tabulate (>=0.9.0)"]
+parquet = ["pyarrow (>=10.0.1)"]
+performance = ["bottleneck (>=1.3.6)", "numba (>=0.56.4)", "numexpr (>=2.8.4)"]
+plot = ["matplotlib (>=3.6.3)"]
+postgresql = ["SQLAlchemy (>=2.0.0)", "adbc-driver-postgresql (>=0.8.0)", "psycopg2 (>=2.9.6)"]
+pyarrow = ["pyarrow (>=10.0.1)"]
+spss = ["pyreadstat (>=1.2.0)"]
+sql-other = ["SQLAlchemy (>=2.0.0)", "adbc-driver-postgresql (>=0.8.0)", "adbc-driver-sqlite (>=0.8.0)"]
+test = ["hypothesis (>=6.46.1)", "pytest (>=7.3.2)", "pytest-xdist (>=2.2.0)"]
+xml = ["lxml (>=4.9.2)"]
 
 [[package]]
 name = "pandocfilters"
@@ -2714,6 +2799,17 @@ files = [
 
 [package.extras]
 dev = ["backports.zoneinfo", "black", "build", "freezegun", "mdx_truly_sane_lists", "mike", "mkdocs", "mkdocs-awesome-pages-plugin", "mkdocs-gen-files", "mkdocs-literate-nav", "mkdocs-material (>=8.5)", "mkdocstrings[python]", "msgspec", "mypy", "orjson", "pylint", "pytest", "tzdata", "validate-pyproject[all]"]
+
+[[package]]
+name = "pytz"
+version = "2025.2"
+description = "World timezone definitions, modern and historical"
+optional = false
+python-versions = "*"
+files = [
+    {file = "pytz-2025.2-py2.py3-none-any.whl", hash = "sha256:5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00"},
+    {file = "pytz-2025.2.tar.gz", hash = "sha256:360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3"},
+]
 
 [[package]]
 name = "pywin32"
@@ -3772,6 +3868,17 @@ files = [
 ]
 
 [[package]]
+name = "tzdata"
+version = "2025.2"
+description = "Provider of IANA time zone data"
+optional = false
+python-versions = ">=2"
+files = [
+    {file = "tzdata-2025.2-py2.py3-none-any.whl", hash = "sha256:1a403fada01ff9221ca8044d701868fa132215d84beb92242d9acd2147f667a8"},
+    {file = "tzdata-2025.2.tar.gz", hash = "sha256:b60a638fcc0daffadf82fe0f57e53d06bdec2f36c4df66280ae79bce6bd6f2b9"},
+]
+
+[[package]]
 name = "uri-template"
 version = "1.3.0"
 description = "RFC 6570 URI Template Processor"
@@ -3904,4 +4011,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.11,<3.13"
-content-hash = "bb97347a6f35e16828f2e163e8d550237abe0fd45bc2df7f760fa2b20b21dc38"
+content-hash = "4fde159517899209a29c99dd6bc4d7f74a329096336cb2d0be7c9b653d3437bd"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ tqdm = "^4.66.5"
 photutils = "^2.0.1"
 jupyter = "^1.1.1"
 ipympl = "^0.9.7"
+pandas = "^2.2.3"
 
 [build-system]
 requires = ["poetry-core"]

--- a/shell_scripts/nirspec.bash
+++ b/shell_scripts/nirspec.bash
@@ -9,13 +9,6 @@ set -e
 # J=48.
 J=1
 
-# JJ is the number of processes for stage 3, where cube_build is a big memory bottleneck. The
-# required memory depends heavily on the final shape of the cube. For Orion, there is lots of
-# empty space in the cubes with the default coordinate grids, and about 50 GB of RAM was needed
-# per process. But with ~200GB RAM, the 3 NIRSpec cubes can be built simultaneously, which saves
-# some time for this slow step.
-JJ=1
-
 # Use these if there's too much multithreading. On machines with high core counts, numpy etc can
 # sometimes launch a large number of threads. This doesn't give much speedup if multiprocessing
 # is used already.

--- a/shell_scripts/nirspec_nsclean.bash
+++ b/shell_scripts/nirspec_nsclean.bash
@@ -80,7 +80,7 @@ parallel_shorthand () {
 # background imprint
 pipeline_jobs -s 1 -o $OUT_BKGI $IN_BKGI
 mv strun_calwebb_detector1_jobs.sh jobs_bkgi_1.sh
-parallel_shorthand 1 bkgi_1
+parallel_shorthand $J bkgi_1
 
 # background
 pipeline_jobs -s 1 -o $OUT_BKG $IN_BKG
@@ -97,21 +97,33 @@ pipeline_jobs -s 1 -o $OUT_SCI $IN_SCI
 mv strun_calwebb_detector1_jobs.sh jobs_sci_1.sh
 parallel_shorthand $J sci_1
 
-# NSClean is now run in the pipeline. Results are slightly different for the following reasons:
-# - There are more settings
-# - The mask is created on-the-fly
-# - The subtraction is done at every frame before ramp fit step
-# Therefore we keep nirspec_nsclean.bash around for now.
+# -- NSClean --
+# _____________
 
-# background stage 2
-pipeline_jobs -s 2 -i $OUT_BKGI -o $OUT_BKG $IN_BKG
+OUT_PFX_NSC=${OUT_PFX}_nsclean
+OUT_SCI_NSC=$HERE/$OUT_PFX_NSC/science
+OUT_SCII_NSC=$HERE/$OUT_PFX_NSC/science_imprint
+OUT_BKG_NSC=$HERE/$OUT_PFX_NSC/background
+OUT_BKGI_NSC=$HERE/$OUT_PFX_NSC/background_imprint
+
+# nsclean run is a wrapper around nsclean, and should be on the command line PATH when pdrs4all
+# package is pip installed
+parallel -j $J nsclean_run {} $OUT_BKG_NSC/stage1/{/} ::: $OUT_BKG/stage1/*rate.fits
+parallel -j $J nsclean_run {} $OUT_BKGI_NSC/stage1/{/} ::: $OUT_BKGI/stage1/*rate.fits
+parallel -j $J nsclean_run {} $OUT_SCII_NSC/stage1/{/} ::: $OUT_SCII/stage1/*rate.fits
+parallel -j $J nsclean_run {} $OUT_SCI_NSC/stage1/{/} ::: $OUT_SCI/stage1/*rate.fits
+
+# the rest of the steps with the cleaned data
+
+# background stage 2 (point input to NSclean output dirs)
+pipeline_jobs -s 2 -i $OUT_BKGI_NSC --intermediate_dir $OUT_BKG_NSC -o $OUT_BKG $IN_BKG
 mv strun_calwebb_spec2_jobs.sh jobs_bkg_2.sh
-parallel_shorthand 1 bkg_2
+parallel_shorthand $J bkg_2
 
 # science stage 2
-pipeline_jobs -s 2 -i $OUT_SCII -o $OUT_SCI $IN_SCI
+pipeline_jobs -s 2 -i $OUT_SCII_NSC --intermediate_dir $OUT_SCI_NSC -o $OUT_SCI $IN_SCI
 mv strun_calwebb_spec2_jobs.sh jobs_sci_2.sh
-parallel_shorthand 4 sci_2
+parallel_shorthand $J sci_2
 
 # science stage 3
 pipeline_jobs -s 3 --mosaic -b $OUT_BKG -o $OUT_SCI $IN_SCI

--- a/shell_scripts/nirspec_nsclean.bash
+++ b/shell_scripts/nirspec_nsclean.bash
@@ -7,14 +7,7 @@ set -e
 # J is the number of processes for stage 1 and 2. The recommended limit, is to make sure you
 # have about 10 GB of RAM per process. For the science cluster at ST, with 512 GB RAM, I use
 # J=48.
-J=1
-
-# JJ is the number of processes for stage 3, where cube_build is a big memory bottleneck. The
-# required memory depends heavily on the final shape of the cube. For Orion, there is lots of
-# empty space in the cubes with the default coordinate grids, and about 50 GB of RAM was needed
-# per process. But with ~200GB RAM, the 3 NIRSpec cubes can be built simultaneously, which saves
-# some time for this slow step.
-JJ=1
+J=6
 
 # Use these if there's too much multithreading. On machines with high core counts, numpy etc can
 # sometimes launch a large number of threads. This doesn't give much speedup if multiprocessing

--- a/shell_scripts/postprocess_nirspec.bash
+++ b/shell_scripts/postprocess_nirspec.bash
@@ -50,8 +50,11 @@ done
 # WCS correction needs to happen here
 python3 -m pdrs4all.postprocess.nirspec_wcs_calibrate_stitch cubes/default/*s3d.fits --output_dir cubes/default_wcscorr
 
-# templates from default cubes (no wcs corr)
-extract_templates "$ROOT"/regions/aper_T_DF_extraction.reg cubes/default/*s3d.fits --template_names "HII" "Atomic" "DF3" "DF2" "DF1" -o templates/default.ecsv
+# templates from both cubes, both stitched and not stitched
+extract_templates "$ROOT"/regions/aper_T_DF_extraction.reg cubes/default/*s3d.fits --template_names "HII" "Atomic" "DF3" "DF2" "DF1" -o templates/default_nostitch.ecsv
 
-# templates from wcs corrected cube
-extract_templates "$ROOT"/regions/aper_T_DF_extraction.reg cubes/default_wcscorr/nirspec_naive_stitch_wcscorr_s3d.fits --template_names "HII" "Atomic" "DF3" "DF2" "DF1" -o templates/default_wcscorr.ecsv
+extract_templates "$ROOT"/regions/aper_T_DF_extraction.reg cubes/default/*s3d.fits --template_names "HII" "Atomic" "DF3" "DF2" "DF1" --apply_offsets --reference_segment 2 -o templates/default_addstitch.ecsv
+
+extract_templates "$ROOT"/regions/aper_T_DF_extraction.reg cubes/default_wcscorr/nirspec_naive_stitch_wcscorr_s3d.fits --template_names "HII" "Atomic" "DF3" "DF2" "DF1" -o templates/default_wcscorr_nostitch.ecsv
+
+extract_templates "$ROOT"/regions/aper_T_DF_extraction.reg cubes/default_wcscorr/nirspec_naive_stitch_wcscorr_s3d.fits --template_names "HII" "Atomic" "DF3" "DF2" "DF1" --apply_offsets --reference_segment 2 -o templates/default_wcscorr_addstitch.ecsv

--- a/shell_scripts/postprocess_nirspec.bash
+++ b/shell_scripts/postprocess_nirspec.bash
@@ -55,6 +55,6 @@ extract_templates "$ROOT"/regions/aper_T_DF_extraction.reg cubes/default/*s3d.fi
 
 extract_templates "$ROOT"/regions/aper_T_DF_extraction.reg cubes/default/*s3d.fits --template_names "HII" "Atomic" "DF3" "DF2" "DF1" --apply_offsets --reference_segment 2 -o templates/default_addstitch.ecsv
 
-extract_templates "$ROOT"/regions/aper_T_DF_extraction.reg cubes/default_wcscorr/nirspec_naive_stitch_wcscorr_s3d.fits --template_names "HII" "Atomic" "DF3" "DF2" "DF1" -o templates/default_wcscorr_nostitch.ecsv
+extract_templates "$ROOT"/regions/aper_T_DF_extraction.reg cubes/default_wcscorr/Level3* --template_names "HII" "Atomic" "DF3" "DF2" "DF1" -o templates/default_wcscorr_nostitch.ecsv
 
-extract_templates "$ROOT"/regions/aper_T_DF_extraction.reg cubes/default_wcscorr/nirspec_naive_stitch_wcscorr_s3d.fits --template_names "HII" "Atomic" "DF3" "DF2" "DF1" --apply_offsets --reference_segment 2 -o templates/default_wcscorr_addstitch.ecsv
+extract_templates "$ROOT"/regions/aper_T_DF_extraction.reg cubes/default_wcscorr/Level3* --template_names "HII" "Atomic" "DF3" "DF2" "DF1" --apply_offsets --reference_segment 2 -o templates/default_wcscorr_addstitch.ecsv


### PR DESCRIPTION
Contents
- Try out the new `clean_flicker_noise` step. The original nirspec bash script is now nirspec_nsclean.bash; last time I tested, it still provides better results. We can try to figure out how to use our nsclean mask in combination with clean_flicker_noise.
- Changes to the nirspec WCS correction. It is now applied to the individual channels as well, instead of just the naively merged one.
- Use the LIKELY method in the `ramp_fit` step, instead of the `jump_step`. This slightly improves the saturation/leakage issues for the brightest lines (e.g. S IV 10.5 um). The `jump_step` is now disabled.
